### PR TITLE
Compile and upload builds via GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,78 @@
+#Template from: https://github.com/ThreeDeeJay/GitHub-Actions-build-templates/blob/main/Windows-MSBuild.yml
+name: Build
+
+env:
+  Branch: ${{github.ref_name}}
+  Configuration: Release
+  Artifacts: x64\Release
+  Solution: GTAVOVR.sln
+
+on:
+  push:
+    Branches: $Branch
+  pull_request:
+    Branches: $Branch
+  workflow_dispatch:
+
+jobs:
+  Windows:
+    runs-on: windows-2019
+    steps:
+
+    - name: Clone repo and submodules
+      run: git clone --recurse-submodules https://github.com/${{github.repository}}.git . --branch ${{env.Branch}}
+
+    - name: Get current date, commit hash and count
+      run: |
+        echo "CommitDate=$(git show -s --date=format:'%Y-%m-%d' --format=%cd)" >> $env:GITHUB_ENV
+        echo "CommitHashShort=$(git rev-parse --short=7 HEAD)" >> $env:GITHUB_ENV
+        echo "CommitCount=$(git rev-list --count HEAD)" >> $env:GITHUB_ENV
+
+    - name: Add MSBuild to PATH
+      uses: microsoft/setup-msbuild@v1.0.2
+
+    - name: Restore NuGet packages
+      working-directory: ${{env.GITHUB_WORKSPACE}}
+      run: nuget restore ${{env.Solution}}
+
+    - name: Install Windows 8.1 SDK
+      shell: powershell
+      run: |
+        Invoke-WebRequest -Method Get -Uri https://go.microsoft.com/fwlink/p/?LinkId=323507 -OutFile sdksetup.exe -UseBasicParsing
+        Start-Process -Wait sdksetup.exe -ArgumentList "/q", "/norestart", "/features", "OptionId.WindowsDesktopSoftwareDevelopmentKit", "OptionId.NetFxSoftwareDevelopmentKit"
+
+    - name: Install vcpkg
+      uses: lukka/run-vcpkg@v11
+      with:
+        vcpkgGitCommitId: 654410ee8e11f0610c11a4a49a8827a84be5e187
+
+    - name: Install dependencies
+      run: |
+        vcpkg install glew:x64-windows-static openvr:x64-windows minhook:x64-windows
+        copy "C:\a\GTAV_OpenVR\GTAV_OpenVR\vcpkg\installed\x64-windows-static\lib\glew32.lib" "C:\a\GTAV_OpenVR\GTAV_OpenVR\ThirdParty\glew32s.lib"
+        copy "C:\a\GTAV_OpenVR\GTAV_OpenVR\vcpkg\installed\x64-windows\lib\openvr_api.lib" "C:\a\GTAV_OpenVR\GTAV_OpenVR\ThirdParty\openvr_api.lib"
+        copy "C:\a\GTAV_OpenVR\GTAV_OpenVR\vcpkg\installed\x64-windows\lib\minhook.x64.lib" "C:\a\GTAV_OpenVR\GTAV_OpenVR\ThirdParty\libMinHook.x64.lib"
+
+    - name: Build
+      run: msbuild /m ${{env.Solution}} /p:Configuration="${{env.Configuration}}"
+
+    - name: Upload Installer Artifact to GitHub
+      uses: actions/upload-artifact@v4
+      with:
+        name: "${{github.event.repository.name}}_r${{env.CommitCount}}@${{env.CommitHashShort}}"
+        path: "${{github.workspace}}/${{env.Artifacts}}"
+
+    - name: Compress artifacts
+      uses: vimtor/action-zip@v1.1
+      with:
+        files: '${{env.Artifacts}}'
+        dest: "build/${{github.event.repository.name}}_r${{env.CommitCount}}@${{env.CommitHashShort}}.zip"
+
+    - name: GitHub pre-release
+      uses: "marvinpinto/action-automatic-releases@latest"
+      with:
+        repo_token: "${{secrets.GITHUB_TOKEN}}"
+        automatic_release_tag: "latest"
+        prerelease: false
+        title: "[${{env.CommitDate}}] ${{github.event.repository.name}} r${{env.CommitCount}}@${{env.CommitHashShort}}"
+        files: "build/${{github.event.repository.name}}_r${{env.CommitCount}}@${{env.CommitHashShort}}.zip"

--- a/GTAVOVR/GTAVOVR.vcxproj
+++ b/GTAVOVR/GTAVOVR.vcxproj
@@ -28,26 +28,26 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>

--- a/OVRInject/OVRInject.vcxproj
+++ b/OVRInject/OVRInject.vcxproj
@@ -110,7 +110,7 @@
       <AdditionalLibraryDirectories>$(SolutionDir)\ThirdParty\</AdditionalLibraryDirectories>
     </Link>
     <PostBuildEvent>
-      <Command>copy "C:\dev\GTAVOVR\x64\Debug\OVRInject.dll" "C:\Program Files (x86)\Steam\steamapps\common\Grand Theft Auto V\OVRInject.dll"</Command>
+      <Command>REM copy "C:\dev\GTAVOVR\x64\Debug\OVRInject.dll" "C:\Program Files (x86)\Steam\steamapps\common\Grand Theft Auto V\OVRInject.dll"</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -150,7 +150,7 @@
       <AdditionalLibraryDirectories>$(SolutionDir)\ThirdParty\</AdditionalLibraryDirectories>
     </Link>
     <PostBuildEvent>
-      <Command>copy "C:\dev\GTAVOVR\x64\Release\OVRInject.dll" "C:\Program Files (x86)\Steam\steamapps\common\Grand Theft Auto V\OVRInject.dll"</Command>
+      <Command>REM copy "C:\dev\GTAVOVR\x64\Release\OVRInject.dll" "C:\Program Files (x86)\Steam\steamapps\common\Grand Theft Auto V\OVRInject.dll"</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/OVRInjectShim/OVRInjectShim.vcxproj
+++ b/OVRInjectShim/OVRInjectShim.vcxproj
@@ -107,7 +107,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
     <PostBuildEvent>
-      <Command>copy "C:\dev\GTAVOVR\x64\Debug\OVRInjectShim.dll" "C:\Program Files (x86)\Steam\steamapps\common\Grand Theft Auto V\OVRInjectShim.dll"</Command>
+      <Command>REM copy "C:\dev\GTAVOVR\x64\Debug\OVRInjectShim.dll" "C:\Program Files (x86)\Steam\steamapps\common\Grand Theft Auto V\OVRInjectShim.dll"</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -144,7 +144,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
     <PostBuildEvent>
-      <Command>copy "C:\dev\GTAVOVR\x64\Release\OVRInjectShim.dll" "C:\Program Files (x86)\Steam\steamapps\common\Grand Theft Auto V\OVRInjectShim.dll"</Command>
+      <Command>REM copy "C:\dev\GTAVOVR\x64\Release\OVRInjectShim.dll" "C:\Program Files (x86)\Steam\steamapps\common\Grand Theft Auto V\OVRInjectShim.dll"</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>


### PR DESCRIPTION
Uploads binaries with updated dependencies to the workflow artifact (temporary) and GitHub releases latest tag (overwriting old ones) every commit
- Upgraded VC v140 (2019)
- Commented out commands to copy DLL to the game folder since obviously it doesn't exist in the cloud runner so it failed

https://github.com/ThreeDeeJay/GTAV_OpenVR/releases/tag/latest